### PR TITLE
Feat/stream by enumerator

### DIFF
--- a/Acceleratio.XCellKit/SpreadsheetCell.cs
+++ b/Acceleratio.XCellKit/SpreadsheetCell.cs
@@ -25,6 +25,8 @@ namespace Acceleratio.XCellKit
         private static readonly Cell openXmlCellElementForWriting = new Cell();
 
         private object _value;
+        private bool? _wrapTextExplicit;
+        private bool _wrapTextInternal = false;
 
         public object Value
         {
@@ -32,7 +34,7 @@ namespace Acceleratio.XCellKit
             set
             {
                 _value = value;
-                WrapText = _value != null && (_value.ToString().Contains("\n") || _value.ToString().Length > 200);
+                _wrapTextInternal = _value != null && (_value.ToString().Contains("\n") || _value.ToString().Length > 200);
             }
         }
 
@@ -52,7 +54,12 @@ namespace Acceleratio.XCellKit
         public double ImageScaleFactor { get; set; }
         public System.Drawing.Size? MergedCellsRange { get; set; }
         public bool ParticipatesInAutoWidthColumnCalculation { get; set; }
-        public bool WrapText { get; private set; }
+
+        public bool WrapText
+        {
+            get => _wrapTextExplicit.GetValueOrDefault(_wrapTextInternal);
+            set => _wrapTextExplicit = value;
+        }
 
         public SpreadsheetCell()
         {

--- a/Acceleratio.XCellKit/SpreadsheetWorksheet.cs
+++ b/Acceleratio.XCellKit/SpreadsheetWorksheet.cs
@@ -313,13 +313,17 @@ namespace Acceleratio.XCellKit
                 {
                     continue;
                 }
-                var enumerator = table.Value.GetStreamingEnumerator();
-                var tableRowPosition = table.Value.StreamedRowsSoFar;
-                while (enumerator.MoveNext())
+
+                using (var enumerator = table.Value.GetStreamingEnumerator())
                 {
-                    var row = enumerator.Current;
-                    row.WriteRow(writer, table.Key.ColumnIndex, table.Key.RowIndex + tableRowPosition + 1, stylesManager, hyperlinkManager, drawingsManager);
-                    tableRowPosition++;
+                    var tableRowPosition = table.Value.StreamedRowsSoFar;
+                    while (enumerator.MoveNext())
+                    {
+                        var row = enumerator.Current;
+                        row.WriteRow(writer, table.Key.ColumnIndex, table.Key.RowIndex + tableRowPosition + 1,
+                            stylesManager, hyperlinkManager, drawingsManager);
+                        tableRowPosition++;
+                    }
                 }
             }
 


### PR DESCRIPTION
Added optional wrapText handling, will respect if set explicitly. 
Streaming can now be accomplished with two ways.
1. using the event as before
2. by using an enumerator

wrote an additional test for the enumerator behavior.

I will finish this PR right away because i need it bad, but feel free to comment.