### PR TITLE
New Properties to SpreadsheetRow added

### DIFF
--- a/SysKit.XCellKit/SpreadsheetRow.cs
+++ b/SysKit.XCellKit/SpreadsheetRow.cs
@@ -9,6 +9,8 @@ namespace SysKit.XCellKit
     {
         public double? RowHeight { get; set; }
         public bool IsVisible { get; set; } = true;
+        public bool IsExpanded { get; set; } = true;
+        public bool IsMaster { get; set; } = true;
         public SpreadsheetRow()
         {
             RowCells = new List<SpreadsheetCell>();
@@ -45,6 +47,16 @@ namespace SysKit.XCellKit
             if (!IsVisible)
             {
                 var hiddenAttribute = new OpenXmlAttribute("hidden", null, 1.ToString());
+                attributeList.Add(hiddenAttribute);
+            }
+            if (!IsExpanded)
+            {
+                var hiddenAttribute = new OpenXmlAttribute("collapsed", null, 1.ToString());
+                attributeList.Add(hiddenAttribute);
+            }
+            if (!IsMaster)
+            {
+                var hiddenAttribute = new OpenXmlAttribute("outlineLevel", null, 1.ToString());
                 attributeList.Add(hiddenAttribute);
             }
 


### PR DESCRIPTION
I added a couple of new attributes to the SpreadsheetRow class

- IsExpanded: adds a "collapsed=1" xml attribute to the row if false which indicates that the row in question is collapsed. The default value is true
- IsMaster: adds a "outlineLevel=1" xml attribute to the row if false which indicates that the row in question is at the second level. [Maybe this will help to visualize.](http://prntscr.com/mtgizd) The default value is also true

Maybe the IsMaster flag could be instead be something like a OutlineLevel (integer) which will then directly map tu the desired outline level, the default would be 0 (unset). But for the SSM MasterDetail Excel feature the IsMaster flag is enough since there are only 2 levels needed

