### PR TITLE
Further changes to row grouping and other improvements

### DIFF
--- a/SysKit.XCellKit/HeaderCellStyle.cs
+++ b/SysKit.XCellKit/HeaderCellStyle.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Color = System.Drawing.Color;
+using Font = System.Drawing.Font;
+
+namespace SysKit.XCellKit
+{
+    public class HeaderCellStyle
+    {
+        public Color? BackgroundColor { get; set; }
+        public Color? ForegroundColor { get; set; }
+        public Font Font { get; set; }
+    }
+}

--- a/SysKit.XCellKit/SpreadsheetStyle.cs
+++ b/SysKit.XCellKit/SpreadsheetStyle.cs
@@ -33,6 +33,7 @@ namespace SysKit.XCellKit
             {
                 var fontid = Font.ToString();
                 sb.Append(fontid);
+                sb.Append(Font.Style);
             }
             if (Alignment.HasValue)
             {

--- a/SysKit.XCellKit/SpreadsheetStylesManager.cs
+++ b/SysKit.XCellKit/SpreadsheetStylesManager.cs
@@ -190,6 +190,10 @@ namespace SysKit.XCellKit
                     {
                         newFont.Bold = new Bold();
                     }
+                    if (style.Font.Italic)
+                    {
+                        newFont.Italic = new Italic();
+                    }
                     if (style.ForegroundColor != null)
                     {
                         newFont.Color = new Color() { Rgb = String.Format("{0:X2}{1:X2}{2:X2}{3:X2}", style.ForegroundColor.Value.A, style.ForegroundColor.Value.R, style.ForegroundColor.Value.G, style.ForegroundColor.Value.B) };

--- a/SysKit.XCellKit/SpreadsheetWorksheet.cs
+++ b/SysKit.XCellKit/SpreadsheetWorksheet.cs
@@ -51,7 +51,7 @@ namespace SysKit.XCellKit
             AddTable(table, 1, _maxRowIndex + 1);
         }
 
-        public void AddTable(SpreadsheetTable table, int columnIndex, int rowIndex)
+        public void AddTable(SpreadsheetTable table, int columnIndex, int rowIndex, HeaderCellStyle headerCellStyle = null)
         {
             if (_addAdditionalItemsDisabled)
             {
@@ -64,6 +64,12 @@ namespace SysKit.XCellKit
                 var column = table.Columns[i];
                 var headerCell = new SpreadsheetCell();
                 headerCell.Value = column.Name;
+                if (headerCellStyle != null)
+                {
+                    headerCell.BackgroundColor = headerCellStyle.BackgroundColor;
+                    headerCell.ForegroundColor = headerCellStyle.ForegroundColor;
+                    headerCell.Font = headerCellStyle.Font;
+                }
                 headerRow.AddCell(headerCell);
                 trackMaxChars(columnIndex + i, headerCell);
             }
@@ -190,6 +196,8 @@ namespace SysKit.XCellKit
             {
                new KeyValuePair<string, string>( "r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships")
             });
+
+            writeSheetProperties(writer);
             writeFrozenFirstColumn(writer);
             writeColumns(writer);
             writeSheetData(writer, stylesManager, hyperLinksManager, DrawingsManager);
@@ -204,6 +212,14 @@ namespace SysKit.XCellKit
         private void writeDrawings(WorksheetPart part, OpenXmlWriter writer)
         {
             DrawingsManager.WriteDrawings(part, writer);
+        }
+
+        private void writeSheetProperties(OpenXmlWriter writer)
+        {
+            writer.WriteStartElement(new SheetProperties());
+            writer.WriteStartElement(new OutlineProperties(), new List<OpenXmlAttribute>() { new OpenXmlAttribute("summaryBelow", null, 0.ToString()) });
+            writer.WriteEndElement();
+            writer.WriteEndElement();
         }
 
         private void writeFrozenFirstColumn(OpenXmlWriter writer)

--- a/SysKit.XCellKit/SysKit.XCellKit.csproj
+++ b/SysKit.XCellKit/SysKit.XCellKit.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ChartExport\Models\ChartSettings.cs" />
     <Compile Include="ChartExport\Models\GanttData.cs" />
     <Compile Include="BarSpreadsheetChart.cs" />
+    <Compile Include="HeaderCellStyle.cs" />
     <Compile Include="PieSpreadsheetChart.cs" />
     <Compile Include="LineSpreadsheetChart.cs" />
     <Compile Include="GanttSpreadsheetChart.cs" />

--- a/SysKit.XCellKit/Tables/SpreadsheetTable.cs
+++ b/SysKit.XCellKit/Tables/SpreadsheetTable.cs
@@ -34,9 +34,11 @@ namespace SysKit.XCellKit
             _streamingMode = false;
             FillLastCellInRow = true;
             ShowHeaderRow = true;
+            StyleName = "TableStyleLight11";
         }
         public string Name { get; private set; }
         public List<SpreadsheetTableColumn> Columns { get; set; }
+        public string StyleName { get; set; }
 
         public int RowCount
         {
@@ -168,7 +170,7 @@ namespace SysKit.XCellKit
                 }
                 i++;
             }
-            TableStyleInfo tableStyle = new TableStyleInfo() { Name = "TableStyleLight9", ShowFirstColumn = false, ShowLastColumn = false, ShowRowStripes = true, ShowColumnStripes = false, };
+            TableStyleInfo tableStyle = new TableStyleInfo() { Name = StyleName, ShowFirstColumn = false, ShowLastColumn = false, ShowRowStripes = false, ShowColumnStripes = false, };
             if (autoFilter != null)
             {
                 table.Append(autoFilter);

--- a/SysKit.XCellKit/Tables/SpreadsheetTable.cs
+++ b/SysKit.XCellKit/Tables/SpreadsheetTable.cs
@@ -34,7 +34,7 @@ namespace SysKit.XCellKit
             _streamingMode = false;
             FillLastCellInRow = true;
             ShowHeaderRow = true;
-            StyleName = "TableStyleLight11";
+            StyleName = "TableStyleLight9";
         }
         public string Name { get; private set; }
         public List<SpreadsheetTableColumn> Columns { get; set; }

--- a/SysKit.XCellKit/Tables/SpreadsheetTable.cs
+++ b/SysKit.XCellKit/Tables/SpreadsheetTable.cs
@@ -170,7 +170,7 @@ namespace SysKit.XCellKit
                 }
                 i++;
             }
-            TableStyleInfo tableStyle = new TableStyleInfo() { Name = StyleName, ShowFirstColumn = false, ShowLastColumn = false, ShowRowStripes = false, ShowColumnStripes = false, };
+            TableStyleInfo tableStyle = new TableStyleInfo() { Name = StyleName, ShowFirstColumn = false, ShowLastColumn = false, ShowRowStripes = true, ShowColumnStripes = false, };
             if (autoFilter != null)
             {
                 table.Append(autoFilter);


### PR DESCRIPTION
- Created class HeaderCellStyle which contains styling info to be applied on the table header cells.
- Added Font style recording to the SpreadsheetStyle.GetIndentifier method. The problem was that, for example, a (Calibri, 11, Italic) font was treated the same as a (Calibri, 11, Bold/Regular) font. 
- Added Italic font handling
- Added the possibility to set one of the built-in table styles that Excel is providing (Design -> Table Styles). **TableStyleLight9** is set as default.
![Screenshot_3](https://user-images.githubusercontent.com/33314617/55066661-8b9e0080-507e-11e9-9cfc-5ab4c77e4816.png)



